### PR TITLE
BF: xyzt units and validation on load

### DIFF
--- a/.github/workflows/push_pr.yml
+++ b/.github/workflows/push_pr.yml
@@ -12,7 +12,7 @@ jobs:
     strategy:
         matrix:
             os: ["ubuntu-latest"]
-            python-version: ["3.7", "3.8", "3.9", "3.10", "3.11"]
+            python-version: ["3.8", "3.9", "3.10", "3.11"]
 
     steps:
       - uses: actions/checkout@v3

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 This document contains the nifti_mrs_tools release history in reverse chronological order.
 
+1.0.1 (Friday 28th July 2023)
+-----------------------------
+- Ensure that the xyzt_units header is correctly set to (mm, s)
+
 1.0.0 (Friday 7th July 2023)
 ----------------------------
 - Major version increment due to breaking API changes.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,9 @@ This document contains the nifti_mrs_tools release history in reverse chronologi
 
 1.0.1 (Friday 28th July 2023)
 -----------------------------
-- Ensure that the xyzt_units header is correctly set to (mm, s)
+- Ensure that the xyzt_units header is correctly set to (mm, s).
+- Validation on creation of a NIfTI-MRS object can now be turned off.
+- Python 3.7 now in [end of life](https://devguide.python.org/versions/) status and is no longer supported.
 
 1.0.0 (Friday 7th July 2023)
 ----------------------------

--- a/setup.cfg
+++ b/setup.cfg
@@ -9,10 +9,10 @@ license = BSD 3-Clause License
 license_files = LICENSE
 classifiers =
     Programming Language :: Python :: 3
-    Programming Language :: Python :: 3.7
     Programming Language :: Python :: 3.8
     Programming Language :: Python :: 3.9
     Programming Language :: Python :: 3.10
+    Programming Language :: Python :: 3.11
 author = William Clarke
 author_email = william.clarke@ndcn.ox.ac.uk
 
@@ -21,7 +21,7 @@ install_requires =
     numpy
     nibabel
     fslpy
-python_requires = >=3.7
+python_requires = >=3.8
 
 [options.extras_require]
 VIS =

--- a/src/nifti_mrs/create_nmrs.py
+++ b/src/nifti_mrs/create_nmrs.py
@@ -141,6 +141,11 @@ def gen_nifti_mrs_hdr_ext(data, dwelltime, hdr_ext, affine=None, nifti_version=2
     v_minor = nifti_mrs_version[1]
     header['intent_name'] = f'mrs_v{v_major}_{v_minor}'.encode()
 
+    # Ensure that xyzt_units is set correctly
+    # define NIFTI_UNITS_MM      2 /! NIFTI code for millimeters. /
+    # define NIFTI_UNITS_SEC     8 /! NIFTI code for seconds. /
+    header.set_xyzt_units(xyz=2, t=8)
+
     # Add header extension to header
     json_s = hdr_ext.to_json()
     extension = nib.nifti1.Nifti1Extension(44, json_s.encode('UTF-8'))

--- a/tests/test_create_nmrs.py
+++ b/tests/test_create_nmrs.py
@@ -36,6 +36,8 @@ def test_gen_new_nifti_mrs(tmp_path):
     assert nmrs.dim_tags == ['DIM_COIL', None, None]
     assert 'dim_5' in nmrs.hdr_ext
 
+    assert nmrs.header.get_xyzt_units() == ('mm', 'sec')
+
     nmrs.save(tmp_path / 'out')
     assert (tmp_path / 'out.nii.gz').exists()
 


### PR DESCRIPTION
- Ensure that the xyzt_units header is correctly set to (mm, s).
- Validation on creation of a NIfTI-MRS object can now be turned off.
- Python 3.7 now in [end of life](https://devguide.python.org/versions/) status and is no longer supported.
