### PR TITLE
`{str(x)}` → `{x}`

### DIFF
--- a/src/nifti_mrs/nifti_mrs.py
+++ b/src/nifti_mrs/nifti_mrs.py
@@ -139,7 +139,7 @@ class NIFTI_MRS():
                     self.image.shape,
                     np.max((self._hdr_ext.ndim, self.image.ndim)))
             except validator.headerExtensionError as exc:
-                print(f"This file's header extension is currently invalid. Reason: {str(exc)}")
+                print(f"This file's header extension is currently invalid. Reason: {exc}")
 
         try:
             self.nucleus


### PR DESCRIPTION
Casting to `str` is redundant, that is the default.

From [Format Specification Mini-Language](https://docs.python.org/3/library/string.html#format-specification-mini-language):
> A general convention is that an empty format specification produces the same result as if you had called [`str()`](https://docs.python.org/3/library/stdtypes.html#str) on the value. A non-empty format specification typically modifies the result.