### PR TITLE
Exclude contents of subdirectories of the standard submodule

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,1 +1,2 @@
 LICENSE
+exclude src/nifti_mrs/standard/*/*


### PR DESCRIPTION
Fixes #24.

This is perhaps not the most elegant fix, but it appears to be effective, correctly excluding `nifti_mrs/standard/explanatory_doc/conf.py` from the sdist and therefore also from the wheels, as test-built with `python3 -m build`.

Note that setuptools is recalcitrant (https://github.com/pypa/setuptools/issues/3260) about this sort of thing.

(If the sdist *does* contain `nifti_mrs/standard/explanatory_doc/conf.py`, as when this PR is applied as a patch to the existing 1.2.0 sdist, then this PR doesn’t keep the wheel from containing it too.)