### PR TITLE
definitions.json file encoding bugfix

### DIFF
--- a/src/nifti_mrs/definitions.py
+++ b/src/nifti_mrs/definitions.py
@@ -18,7 +18,7 @@ else:
     # See https://setuptools.pypa.io/en/latest/userguide/datafiles.html#accessing-data-files-at-runtime
     from importlib_resources import files
 
-data_text = files('nifti_mrs.standard').joinpath('definitions.json').read_text()
+data_text = files('nifti_mrs.standard').joinpath('definitions.json').read_text(encoding='utf-8')
 json_def = json.loads(data_text)
 
 # Carry out translation


### PR DESCRIPTION
Specified UTF-8 file encoding when reading 'definitions.json' - to avoid 'UnicodeDecodeError' when importing modules from fsl_mrs.utils. 