### PR TITLE
BF: Nibabel header extension access

### DIFF
--- a/.github/workflows/push_pr.yml
+++ b/.github/workflows/push_pr.yml
@@ -12,7 +12,7 @@ jobs:
     strategy:
         matrix:
             os: ["ubuntu-latest"]
-            python-version: ["3.8", "3.9", "3.10", "3.11"]
+            python-version: ["3.9", "3.10", "3.11", "3.12", "3.13"]
 
     steps:
       - uses: actions/checkout@v3

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@ This document contains the nifti_mrs_tools release history in reverse chronologi
 
 1.3.1 (Monday 21st October 2024)
 --------------------------------
+- Drop support for python 3.8. Testing extended to python 3.12 and 3.13.
 - Fix compatibility issue with nibabel > 5.3
 
 1.3.0 (Wednesday 26th June 2024)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 This document contains the nifti_mrs_tools release history in reverse chronological order.
 
+1.3.1 (Monday 21st October 2024)
+--------------------------------
+- Fix compatibility issue with nibabel > 5.3
+
 1.3.0 (Wednesday 26th June 2024)
 --------------------------------
 - Added `--full-hdr` argumet to `mrs_tools info` which enables printing of the full header extension.

--- a/setup.cfg
+++ b/setup.cfg
@@ -19,7 +19,7 @@ author_email = william.clarke@ndcn.ox.ac.uk
 [options]
 install_requires =
     numpy
-    nibabel
+    nibabel>=5.3
     fslpy
     importlib_resources;python_version<'3.10'
 python_requires = >=3.8

--- a/setup.cfg
+++ b/setup.cfg
@@ -9,10 +9,11 @@ license = BSD 3-Clause License
 license_files = LICENSE
 classifiers =
     Programming Language :: Python :: 3
-    Programming Language :: Python :: 3.8
     Programming Language :: Python :: 3.9
     Programming Language :: Python :: 3.10
     Programming Language :: Python :: 3.11
+    Programming Language :: Python :: 3.12
+    Programming Language :: Python :: 3.13
 author = William Clarke
 author_email = william.clarke@ndcn.ox.ac.uk
 
@@ -22,7 +23,7 @@ install_requires =
     nibabel>=5.3
     fslpy
     importlib_resources;python_version<'3.10'
-python_requires = >=3.8
+python_requires = >=3.9
 packages = find_namespace:
 package_dir =
     = src

--- a/src/nifti_mrs/nifti_mrs.py
+++ b/src/nifti_mrs/nifti_mrs.py
@@ -118,8 +118,7 @@ class NIFTI_MRS():
                 raise NotNIFTI_MRS('NIFTI-MRS must have a header extension.')
 
             self._hdr_ext = Hdr_Ext.from_header_ext(
-                json.loads(
-                    self.header.extensions[hdr_ext_codes.index(44)].get_content()))
+                self.header.extensions[hdr_ext_codes.index(44)].json())
 
         # Some validation upon creation
         if validate_on_creation:

--- a/src/nifti_mrs/tools/split_merge.py
+++ b/src/nifti_mrs/tools/split_merge.py
@@ -40,7 +40,7 @@ def split(nmrs, dimension, index_or_indices):
         if dimension > (nmrs.ndim - 1) or dimension < 4:
             raise ValueError('Dimension must be one of 4, 5, or 6 (or DIM_TAG string).'
                              f' This data has {nmrs.ndim} dimensions,'
-                             f' i.e. a maximum dimension value of {nmrs.ndim-1}.')
+                             f' i.e. a maximum dimension value of {nmrs.ndim - 1}.')
         dim_index = dimension
     else:
         raise TypeError('Dimension must be an int (4, 5, or 6) or string (DIM_TAG string).')
@@ -164,7 +164,7 @@ def merge(array_of_nmrs, dimension):
         if dimension > (array_of_nmrs[0].ndim - 1) or dimension < 4:
             raise ValueError('Dimension must be one of 4, 5, or 6 (or DIM_TAG string).'
                              f' This data has {array_of_nmrs[0].ndim} dimensions,'
-                             f' i.e. a maximum dimension value of {array_of_nmrs[0].ndim-1}.')
+                             f' i.e. a maximum dimension value of {array_of_nmrs[0].ndim - 1}.')
         dim_index = dimension
     else:
         raise TypeError('Dimension must be an int (4, 5, or 6) or string (DIM_TAG string).')

--- a/src/nifti_mrs/validator.py
+++ b/src/nifti_mrs/validator.py
@@ -35,7 +35,7 @@ def validate_nifti_mrs(nifti_mrs):
 
     # Validate header extension
     validate_hdr_ext(
-        nifti_mrs.header.extensions[0],
+        nifti_mrs.header.extensions[0].text,
         nifti_mrs.shape)
 
     # Validate that any SpectralWidth definition matches pixdim[4]
@@ -97,7 +97,7 @@ def validate_hdr_ext(header_ex, dimension_sizes, data_dimensions=None):
     """
     # 1. Check that header_ext is json
     try:
-        json_dict = header_ex.json()
+        json_dict = json.loads(header_ex)
     except json.JSONDecodeError as exc:
         raise headerExtensionError("Header extension is not json deserialisable.") from exc
 

--- a/src/nifti_mrs/validator.py
+++ b/src/nifti_mrs/validator.py
@@ -40,7 +40,7 @@ def validate_nifti_mrs(nifti_mrs):
 
     # Validate that any SpectralWidth definition matches pixdim[4]
     validate_spectralwidth(
-        nifti_mrs.header.extensions[0].json(),
+        nifti_mrs.header.extensions[0].text,
         nifti_mrs.header['pixdim'][4])
 
 

--- a/src/nifti_mrs/validator.py
+++ b/src/nifti_mrs/validator.py
@@ -35,12 +35,12 @@ def validate_nifti_mrs(nifti_mrs):
 
     # Validate header extension
     validate_hdr_ext(
-        nifti_mrs.header.extensions[0].get_content(),
+        nifti_mrs.header.extensions[0],
         nifti_mrs.shape)
 
     # Validate that any SpectralWidth definition matches pixdim[4]
     validate_spectralwidth(
-        nifti_mrs.header.extensions[0].get_content(),
+        nifti_mrs.header.extensions[0].json(),
         nifti_mrs.header['pixdim'][4])
 
 
@@ -97,7 +97,7 @@ def validate_hdr_ext(header_ex, dimension_sizes, data_dimensions=None):
     """
     # 1. Check that header_ext is json
     try:
-        json_dict = json.loads(header_ex)
+        json_dict = header_ex.json()
     except json.JSONDecodeError as exc:
         raise headerExtensionError("Header extension is not json deserialisable.") from exc
 

--- a/tests/test_script_mrs_tools.py
+++ b/tests/test_script_mrs_tools.py
@@ -7,7 +7,6 @@ Copyright Will Clarke, University of Oxford, 2021'''
 # Imports
 import subprocess
 from pathlib import Path
-import json
 
 import nibabel as nib
 import pytest
@@ -163,8 +162,7 @@ def test_merge(tmp_path):
     assert (tmp_path / 'test_newaxis_merge.nii.gz').exists()
     fna = nib.load(tmp_path / 'test_newaxis_merge.nii.gz')
     hdr_ext_codes = fna.header.extensions.get_codes()
-    hdr_ext = json.loads(
-        fna.header.extensions[hdr_ext_codes.index(44)].get_content())
+    hdr_ext = fna.header.extensions[hdr_ext_codes.index(44)].json()
 
     assert fna.ndim == 7
     assert fna.shape == (1, 1, 1, 4096, 4, 2, 2)
@@ -267,8 +265,7 @@ def test_reshape(tmp_path):
     assert f1.shape == (1, 1, 1, 4096, 4, 4, 4)
 
     hdr_ext_codes = f1.header.extensions.get_codes()
-    hdr_ext = json.loads(
-        f1.header.extensions[hdr_ext_codes.index(44)].get_content())
+    hdr_ext = f1.header.extensions[hdr_ext_codes.index(44)].json()
 
     assert hdr_ext['dim_5'] == 'DIM_COIL'
     assert hdr_ext['dim_6'] == 'DIM_DYN'
@@ -287,8 +284,7 @@ def test_reshape(tmp_path):
     assert f2.shape == (1, 1, 1, 4096, 8, 8)
 
     hdr_ext_codes = f2.header.extensions.get_codes()
-    hdr_ext = json.loads(
-        f2.header.extensions[hdr_ext_codes.index(44)].get_content())
+    hdr_ext = f2.header.extensions[hdr_ext_codes.index(44)].json()
 
     assert hdr_ext['dim_5'] == 'DIM_COIL'
     assert hdr_ext['dim_6'] == 'DIM_DYN'


### PR DESCRIPTION
Fixes header extension access arising from https://github.com/nipy/nibabel/pull/1336

@effigies You gave me plenty of warning about this, and I completely failed to test or do anything about it, but just to let you know that users reported errors like this:
```
File d:\Conda\envs\dan_fsl_mrs\Lib\site-packages\nifti_mrs\nifti_mrs.py:122, in NIFTI_MRS.__init__(self, validate_on_creation, *args, **kwargs)
    117     if 44 not in hdr_ext_codes:
    118         raise NotNIFTI_MRS('NIFTI-MRS must have a header extension.')
    120     self._hdr_ext = Hdr_Ext.from_header_ext(
    121         json.loads(
--> 122             self.header.extensions[hdr_ext_codes.index(44)].get_content()))
    124 # Some validation upon creation
    125 if validate_on_creation:

File d:\Conda\envs\dan_fsl_mrs\Lib\site-packages\nibabel\nifti1.py:455, in NiftiExtension.get_object(self)
    448 """Return the extension content in its runtime representation.
    449 
    450 This method may return a different type for each extension type.
    451 For simple use cases, consider using ``.content``, ``.text`` or ``.json()``
    452 instead.
    453 """
    454 if self._object is None:
--> 455     self._object = self._unmangle(self._content)
    456 return self._object

File d:\Conda\envs\dan_fsl_mrs\Lib\site-packages\nibabel\nifti1.py:388, in NiftiExtension._unmangle(self, content)
    387 def _unmangle(self, content: bytes) -> T:
--> 388     raise NotImplementedError
```
Is this what you intended?
 