### PR TITLE
correct dwelltime when time unit is not second

### DIFF
--- a/src/nifti_mrs/nifti_mrs.py
+++ b/src/nifti_mrs/nifti_mrs.py
@@ -219,7 +219,13 @@ class NIFTI_MRS():
     @property
     def dwelltime(self):
         '''Return dwelltime in seconds'''
-        return self.header['pixdim'][4]
+        t_unit = self.header.get_xyzt_units()[1]
+        dwelltime=self.header['pixdim'][4]
+        if t_unit=="msec":
+            return dwelltime*1e-3
+        if t_unit=="usec":
+            return dwelltime*1e-6
+        return dwelltime
 
     @dwelltime.setter
     def dwelltime(self, new_dt):

--- a/src/nifti_mrs/vis.py
+++ b/src/nifti_mrs/vis.py
@@ -24,7 +24,8 @@ def vis_nifti_mrs(data, display_dim=None, ppmlim=None, plot_avg=False, mask=None
 
     if data.ndim > 4 \
             and 'DIM_COIL' in data.dim_tags\
-            and display_dim != 'DIM_COIL':
+            and display_dim != 'DIM_COIL'\
+            and data.shape[4+data.dim_tags.index('DIM_COIL')]>1:
         print('Performing coil combination')
         data = nifti_mrs_proc.coilcombine(data)
 


### PR DESCRIPTION
This pull request continues with the problem mentioned in #33 
 