### PR TITLE
Bug fix and short hands for nifti mrs dimension reduction

### DIFF
--- a/src/nifti_mrs/nifti_mrs.py
+++ b/src/nifti_mrs/nifti_mrs.py
@@ -475,7 +475,10 @@ class NIFTI_MRS():
         """
         if remove_dim:
             dim = self._dim_tag_to_index(remove_dim)
-            reduced_data = self[:].take(0, axis=dim)
+            if dim==len(self.shape)-1 and self.shape[-1]==1:
+                reduced_data = self[:]
+            else:
+                reduced_data = self[:].take(0, axis=dim)
             new_hdr_ext = self.hdr_ext.copy()
             new_hdr_ext.remove_dim_info(dim - 4)
             new_hd = utils.modify_hdr_ext(
@@ -487,6 +490,16 @@ class NIFTI_MRS():
             return new_obj
         else:
             return NIFTI_MRS(self[:], header=self.header)
+            
+    def remove_dim(self, remove_dim):
+        """Return a copy of this image with a dimension removed. (Intuitive wrapper of copy function with remove_dim.)
+        
+        :param remove_dim: dimension index (4, 5, 6) or tag to remove. Takes first index. Defaults to None/no removal
+        :type remove_dim: str or int, optional
+        :return: Copy of object
+        :rtype: NIFTI_MRS
+        """
+        return self.copy(remove_dim)
 
     def save(self, filepath):
         """Save NIfTI-MRS to file

--- a/src/nifti_mrs/tools/split_merge.py
+++ b/src/nifti_mrs/tools/split_merge.py
@@ -306,3 +306,17 @@ def _merge_dim_header(hdr1, hdr2, dimension, dim_length1, dim_length2):
         # Nothing to merge - still run check
         run_check()
     return out_hdr
+
+def remove_dim(nmrs, remove_dim):
+    """Removes a specficied dimension from a NIFTI_MRS object and returns a copy of the so modified NIFTI_MRS.
+    Intuitive wrapper of NIFTI_MRS member funciton.
+
+    :param nmrs: Input nifti_mrs object from which to remove dim
+    :type nmrs: fsl_mrs.core.nifti_mrs.NIFTI_MRS
+    :param remove_dim: dimension index (4, 5, 6) or tag to remove. Takes first index. 
+    :type remove_dim: str or int
+    :return: A NIFTI_MRS object with dimensionality reduced
+    :rtype: fsl_mrs.core.nifti_mrs.NIFTI_MRS
+    """
+    return nrms.copy(remove_dim)
+


### PR DESCRIPTION
Bug fix: can now remove the trivial last dimension from nifti mrs. 

Added remove_dim functions to nifti mrs tools via the copy function of the NIFTI_MRS class.

Added remove_dim member function to NIFTI_MRS class for more intuitive use.